### PR TITLE
chat-space-routes-finish

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "messages#index"
   resources :users, only: [:edit, :update]
+  resources :groups, only: [:new, :create, :edit, :update]
 end


### PR DESCRIPTION
#what
chat-spaceのグループ機能のルーティングを実装完了

#why
chat-spaceでグループを作成して、チャットを始める際に、コントローラーを動かすために必要なため